### PR TITLE
A301 Alpha 2

### DIFF
--- a/A301.md
+++ b/A301.md
@@ -6,20 +6,88 @@
 
 The A301 API is available through REVLib and will later be available natively through WPILib in the near future.
 
-Follow the instructions in [REV.md](REV.md) to install the latest version of REVLib.
+REVLib should be available in the vendor dependencies of WPILib VS Code, but you can also use this JSON URL directly:
+
+```txt
+https://software-metadata.revrobotics.com/REVLib-2027.json
+```
+
+[Offline Install](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2027.0.0-alpha-4/REVLib-offline-v2027.0.0-alpha-4.zip)
+
+Refer to [WPILib Docs](https://docs.wpilib.org/en/stable/docs/software/vscode-overview/3rd-party-libraries.html) about installing 3rd party libraries, and see [REV.md](REV.md) for the full REVLib changelog.
+
+> [!NOTE]
+> REVLib v2027.0.0-alpha-4 requires A301 v27.0.0-prerelease.15 or later.
+
+### Hardware Client 2
+
+REV Hardware Client 2 (RHC2) is used to update and test the A301:
+
+- [RHC2 for Desktop](https://alpha.rhc2.revrobotics.com/download-site/download.html)
+- [RHC2 IPK for Systemcore](https://alpha.rhc2.revrobotics.com/download-site/debian/rev-robotics-rev-hardware-client-alpha_1.2.1_arm64.ipk) - Install this by clicking "Add Package" on the home screen of Systemcore and selecting this file. It will take a minute or so to start up.
+
+See [REV.md](REV.md) for the full RHC2 changelog.
 
 ### Firmware
 
 > [!IMPORTANT]
 > A301s must be updated to 27.0.0-prerelease.11 or later before use. REVLib and RHC2 will prevent you from running an A301 with an older version.
 
-The recommend method to update the A301 firmware is through REV Hardware Client 2 running directly on Systemcore. Since Systemcore will likely not be connected to internet, you will need to upload the firmware file to RHC2 using the dialog as shown below.
+> [!IMPORTANT]
+> It is highly recommended to update to RHC2 1.2.1 on the Systemcore before updating to A301 27.0.0-prerelease.15, as it handles the transition from the previous spec to the new one.
 
-For downloads and instructions, see [REV.md](REV.md).
+The recommended method to update the A301 firmware is through REV Hardware Client 2 running directly on Systemcore. Since Systemcore will likely not be connected to internet, you will need to upload the firmware file to RHC2 using the dialog as shown below.
 
 ![A301 update on systemcore](A301_Update.png)
 
-The firmware can also be updated from RHC2 on desktop, but a bridging device is required (SPARK Flex, PDH, etc.). To receive the latest firmware in RHC2, enter the following code in the "Downloads" tab of RHC2: `a301-alpha`
+Direct firmware downloads for updating via Systemcore:
+
+- [A301 v2027.0.0-prerelease.15](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.15/a301_27_0_0_prerelease_15.dfu)
+
+> [!NOTE]
+> The firmware can also be updated from RHC2 on desktop, but a bridging device (SPARK Flex, PDH, etc) is **required** for this method. To get the latest version of A301 firmware in RHC2, enter the following code in the "Downloads" tab of RHC2: `a301-alpha`
+
+<details>
+<summary>A301 Firmware Changelog</summary>
+
+#### 2027.0.0-prerelease.15
+
+- New A301 protocol
+- Fix for deceleration asymmetry in voltage mode
+- Enabled configurable status periods
+- Settings save automatically
+- Faster eeprom saving
+- Better rotor estimation during stall
+- Added gearbox and motor life handlers
+- Added user velocity limit during position control
+- Added support for MRC override to run without a driver station
+
+#### 2027.0.0-prerelease.14
+
+- Fixes sensor faults not detected in voltage modes
+- Fixes false failed gearbox detection
+
+#### 2027.0.0-prerelease.12
+
+- Fixes status periods
+- Improves voltage control
+- Replaces output current on status0 with improved average motor current
+- Improves applied output reporting
+
+#### 2027.0.0-prerelease.11
+
+Initial release for A301
+
+</details>
+
+<details>
+<summary>Older downloads (not compatible with REVLib 2027.0.0-alpha-4 or later)</summary>
+
+- [A301 v2027.0.0-prerelease.14](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.14/a301_27_0_0_prerelease_14.dfu)
+- [A301 v2027.0.0-prerelease.12](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.12/a301_27_0_0_prerelease_12.dfu)
+- [A301 v2027.0.0-prerelease.11](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.11/a301_27_0_0_prerelease_11.dfu)
+
+</details>
 
 ## Getting Started
 
@@ -28,10 +96,10 @@ Full code docs for the A301 API can be found here: [Java](https://codedocs.revro
 You can create an A301 object by doing the following:
 
 ```java
-// Create an A301 object on Motioncore channel 0. The A301's CAN ID must be the default value of 3.
+// Create an A301 object on Motioncore channel 0. The A301's CAN ID will be autodetected.
 A301 motor = new A301(CANBusMap.CAN_D0);
 
-// Create an A301 object on Motioncore channel 0, with a non-default CAN ID of 5.
+// Create an A301 object on Motioncore channel 0, with a specific CAN ID of 5.
 A301 motor = new A301(CANBusMap.CAN_D0, 5);
 ```
 

--- a/A301.md
+++ b/A301.md
@@ -48,10 +48,16 @@ motor.setVelocity(100);
 motor.setPosition(5);
 
 // Command the motor to an absolute position (single rotation)
-motor.setAbsolutePosition(0.4, false);
+motor.disableAbsolutePositionContinuousInput(); // Once called, this setting will be saved to the motor
+motor.setAbsolutePosition(0.4);
 
 // Command the motor to an absolute position with continuous input (shortest path)
-motor.setAbsolutePosition(-0.4, true);
+motor.enableAbsolutePositionContinuousInput(); // Once called, this setting will be saved to the motor
+motor.setAbsolutePosition(-0.4);
+
+// Command the motor to a position with a speed constraint in RPM
+motor.setPosition(5, 50);
+motor.setAbsolutePosition(0.4, 50);
 
 // Command the motor to a specific throttle level 
 motor.setThrottle(0.5);

--- a/A301.md
+++ b/A301.md
@@ -16,8 +16,8 @@ https://software-metadata.revrobotics.com/REVLib-2027.json
 
 Refer to [WPILib Docs](https://docs.wpilib.org/en/stable/docs/software/vscode-overview/3rd-party-libraries.html) about installing 3rd party libraries, and see [REV.md](REV.md) for the full REVLib changelog.
 
-> [!NOTE]
-> REVLib v2027.0.0-alpha-4 requires A301 v27.0.0-prerelease.15 or later.
+> [!IMPORTANT]
+> A301 firmware v27.0.0-prerelease.15 introduces a **breaking change** to the A301 CAN protocol. REVLib v2027.0.0-alpha-4 requires firmware v27.0.0-prerelease.15 or later, and firmware v27.0.0-prerelease.15 requires REVLib v2027.0.0-alpha-4 or later — you must update both together.
 
 ### Hardware Client 2
 
@@ -33,8 +33,13 @@ See [REV.md](REV.md) for the full RHC2 changelog.
 > [!IMPORTANT]
 > A301s must be updated to 27.0.0-prerelease.11 or later before use. REVLib and RHC2 will prevent you from running an A301 with an older version.
 
-> [!IMPORTANT]
-> It is highly recommended to update to RHC2 1.2.1 on the Systemcore before updating to A301 27.0.0-prerelease.15, as it handles the transition from the previous spec to the new one.
+> [!WARNING]
+> A301 firmware v27.0.0-prerelease.15 is a **breaking change** to the A301 CAN protocol. You must update REVLib to v2027.0.0-alpha-4 or later to use it, and likewise REVLib v2027.0.0-alpha-4 will not work with older firmware — update both together.
+
+> [!CAUTION]
+> Update RHC2 to **1.2.1 before** updating the A301 to v27.0.0-prerelease.15. RHC2 1.2.1 handles the transition from the previous spec to the new one; older versions of RHC2 do not, and performing the update with an older RHC2 can leave the A301's firmware in a bad state.
+>
+> If this happens, it is recoverable, but not a good time: update RHC2 to 1.2.1, then **force a bootloader update** by enabling the checkbox in the "Advanced" section of the update manager and re-running the update.
 
 The recommended method to update the A301 firmware is through REV Hardware Client 2 running directly on Systemcore. Since Systemcore will likely not be connected to internet, you will need to upload the firmware file to RHC2 using the dialog as shown below.
 
@@ -42,7 +47,7 @@ The recommended method to update the A301 firmware is through REV Hardware Clien
 
 Direct firmware downloads for updating via Systemcore:
 
-- [A301 v2027.0.0-prerelease.15](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.15/a301_27_0_0_prerelease_15.dfu)
+- [A301 v2027.0.0-prerelease.15](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.15/a301_27_0_0_prerelease_15.dfu) - please review warnings above before updating
 
 > [!NOTE]
 > The firmware can also be updated from RHC2 on desktop, but a bridging device (SPARK Flex, PDH, etc) is **required** for this method. To get the latest version of A301 firmware in RHC2, enter the following code in the "Downloads" tab of RHC2: `a301-alpha`

--- a/REV.md
+++ b/REV.md
@@ -1,5 +1,8 @@
 # REV Alpha Software for 2027
 
+> [!NOTE]
+> If you are testing the A301, see [A301.md](A301.md) for everything you need: firmware downloads, version compatibility, and getting started with the API.
+
 ## REVLib
 
 REVLib should be available in the vendor dependencies of WPILib VS Code, but you can also use this JSON URL directly:
@@ -8,12 +11,12 @@ REVLib should be available in the vendor dependencies of WPILib VS Code, but you
 https://software-metadata.revrobotics.com/REVLib-2027.json
 ```
 
-[Offline Install](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2027.0.0-alpha-3/REVLib-offline-v2027.0.0-alpha-3.zip)
+[Offline Install](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/revlib-2027.0.0-alpha-4/REVLib-offline-v2027.0.0-alpha-4.zip)
 
 Refer to [WPILib Docs](https://docs.wpilib.org/en/stable/docs/software/vscode-overview/3rd-party-libraries.html) about installing 3rd party libraries.
 
 > [!NOTE]
-> REVLib v2027.0.0-alpha-4 requires A301 v27.0.0-prerelease.15 or later.
+> REVLib version requirements for A301 firmware are listed in [A301.md](A301.md).
 
 <details>
 <summary>Changelog</summary>
@@ -109,61 +112,7 @@ Refer to [WPILib Docs](https://docs.wpilib.org/en/stable/docs/software/vscode-ov
 
 ### A301
 
-The recommend method to update the A301 firmware is through REV Hardware Client 2 running directly on Systemcore. Since Systemcore will likely not be connected to internet, you will need to upload the firmware file to RHC2 using the dialog:
-
-![A301 update on systemcore](A301_Update.png)
-
-Direct firmware downloads for updating via Systemcore:
-
-- [A301 v2027.0.0-prerelease.15](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.15/a301_27_0_0_prerelease_15.dfu)
-
-> [!IMPORTANT]
-> It is highly recommended to update to RHC2 1.2.1 on the Systemcore before updating to A301 27.0.0-prerelease.15, as it handles the transition from the previous spec to the new one.
-
-> [!NOTE]
-> The firmware can also be updated from RHC2 on desktop, but a bridging device (SPARK Flex, PDH, etc) is **required** for this method. To get the latest version of A301 firmware in RHC2, enter the following code in the "Downloads" tab of RHC2: `a301-alpha`
-
-<details>
-<summary>A301 Firmware Changelog</summary>
-
-#### 2027.0.0-prerelease.15
-
-- New A301 protocol
-- Fix for deceleration asymmetry in voltage mode
-- Enabled configurable status periods
-- Settings save automatically
-- Faster eeprom saving
-- Better rotor estimation during stall
-- Added gearbox and motor life handlers
-- Added user velocity limit during position control
-- Added support for MRC override to run without a driver station
-
-#### 2027.0.0-prerelease.14
-
-- Fixes sensor faults not detected in voltage modes
-- Fixes false failed gearbox detection
-
-#### 2027.0.0-prerelease.12
-
-- Fixes status periods
-- Improves voltage control
-- Replaces output current on status0 with improved average motor current
-- Improves applied output reporting
-
-#### 2027.0.0-prerelease.11
-
-Initial release for A301
-
-</details>
-
-<details>
-<summary>Older downloads (not compatible with REVLib 2027.0.0-alpha-4 or later)</summary>
-
-- [A301 v2027.0.0-prerelease.14](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.14/a301_27_0_0_prerelease_14.dfu)
-- [A301 v2027.0.0-prerelease.12](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.12/a301_27_0_0_prerelease_12.dfu)
-- [A301 v2027.0.0-prerelease.11](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.11/a301_27_0_0_prerelease_11.dfu)
-
-</details>
+A301 firmware downloads, update instructions, and the firmware changelog can be found in [A301.md](A301.md).
 
 ### Misc
 

--- a/REV.md
+++ b/REV.md
@@ -12,8 +12,21 @@ https://software-metadata.revrobotics.com/REVLib-2027.json
 
 Refer to [WPILib Docs](https://docs.wpilib.org/en/stable/docs/software/vscode-overview/3rd-party-libraries.html) about installing 3rd party libraries.
 
+> [!NOTE]
+> REVLib v2027.0.0-alpha-4 requires A301 v27.0.0-prerelease.15 or later.
+
 <details>
 <summary>Changelog</summary>
+
+### REVLib v2027.0.0-alpha-4
+
+- [REVLib] Removes deprecated functions
+- [REVLib] Fixes links in documentation
+- [REVLib] Fixes Sim classes to include CAN Bus ID in name
+- [A301] - Adds new A301-specific CAN specifications
+- [A301] - Removed isContinuous argument from setAbsolutePosition(); replaced with (En/Dis)ableAbsolutePositionContinuousInput()
+- [A301] - Adds a setRelativePositionWithSpeed() and setAbsolutePositionWithSpeed() to run position closed loop control with a speed constraint
+- [A301] - Updates A301(int busId) constructor to autodetect the device ID instead of requiring the device to be the factory default value of 3
 
 ### REVLib v2027.0.0-alpha-3
 
@@ -38,10 +51,35 @@ Refer to [WPILib Docs](https://docs.wpilib.org/en/stable/docs/software/vscode-ov
 
 [RHC2 for Desktop](https://alpha.rhc2.revrobotics.com/download-site/download.html)
 
-[RHC2 IPK for Systemcore](https://alpha.rhc2.revrobotics.com/download-site/debian/rev-robotics-rev-hardware-client-alpha_1.1.1_arm64.ipk) - Install this by clicking "Add Package" on the home screen of Systemcore and selecting this file. It will take a minute or so to start up.
+[RHC2 IPK for Systemcore](https://alpha.rhc2.revrobotics.com/download-site/debian/rev-robotics-rev-hardware-client-alpha_1.2.1_arm64.ipk) - Install this by clicking "Add Package" on the home screen of Systemcore and selecting this file. It will take a minute or so to start up.
 
 <details>
 <summary>Changelog</summary>
+
+## RHC2 1.2.1
+
+- Adds support for new A301 CAN specification introduced in firmware version 27.0.0-prerelease.15
+- Adds ability to specify a speed for position control in A301's run utility
+- Adds a toggle on the Motioncore card to override the robot program to run motors without a driver station
+- Adds gearbox and motor health status cards for A301
+- Fixes devices not showing up on the Hardware page in Safari
+
+## RHC2 1.2.0
+
+- Adds support for REV FTC devices (Control Hub, Expansion Hub, Driver Hub, Driver Station Phone)
+- Adds support for CAN Encoder Adapter
+- Adds search bar for signals on Telemetry page
+- Adds search bar for SPARK configuration tab
+- Adds relative encoder utility to MAXSpline Encoder
+- Fixes sidebar on telemetry expanding when a device has an alert in either run tab
+- Fixes issue reporting
+- Fixes issue where signals would freeze after closing a device
+- Fixes issue with A301 CAN ID change not persisting
+- Fixes issue where firmware versions sometimes do not populate in the update page
+
+### Known Issues
+
+- When connecting to a Control Hub via Wi-Fi, no other computer will be able to see the Control Hub until it is power cycled. The same laptop can continue to see and use the Control Hub even if it reconnects or RHC2 is reopened.
 
 ## RHC2 1.1.1
 
@@ -77,15 +115,28 @@ The recommend method to update the A301 firmware is through REV Hardware Client 
 
 Direct firmware downloads for updating via Systemcore:
 
-- [A301 v2027.0.0-prerelease.14](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.14/a301_27_0_0_prerelease_14.dfu)
-- [A301 v2027.0.0-prerelease.12](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.12/a301_27_0_0_prerelease_12.dfu)
-- [A301 v2027.0.0-prerelease.11](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.11/a301_27_0_0_prerelease_11.dfu)
+- [A301 v2027.0.0-prerelease.15](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.15/a301_27_0_0_prerelease_15.dfu)
+
+> [!IMPORTANT]
+> It is highly recommended to update to RHC2 1.2.1 on the Systemcore before updating to A301 27.0.0-prerelease.15, as it handles the transition from the previous spec to the new one.
 
 > [!NOTE]
 > The firmware can also be updated from RHC2 on desktop, but a bridging device (SPARK Flex, PDH, etc) is **required** for this method. To get the latest version of A301 firmware in RHC2, enter the following code in the "Downloads" tab of RHC2: `a301-alpha`
 
 <details>
 <summary>A301 Firmware Changelog</summary>
+
+#### 2027.0.0-prerelease.15
+
+- New A301 protocol
+- Fix for deceleration asymmetry in voltage mode
+- Enabled configurable status periods
+- Settings save automatically
+- Faster eeprom saving
+- Better rotor estimation during stall
+- Added gearbox and motor life handlers
+- Added user velocity limit during position control
+- Added support for MRC override to run without a driver station
 
 #### 2027.0.0-prerelease.14
 
@@ -102,6 +153,15 @@ Direct firmware downloads for updating via Systemcore:
 #### 2027.0.0-prerelease.11
 
 Initial release for A301
+
+</details>
+
+<details>
+<summary>Older downloads (not compatible with REVLib 2027.0.0-alpha-4 or later)</summary>
+
+- [A301 v2027.0.0-prerelease.14](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.14/a301_27_0_0_prerelease_14.dfu)
+- [A301 v2027.0.0-prerelease.12](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.12/a301_27_0_0_prerelease_12.dfu)
+- [A301 v2027.0.0-prerelease.11](https://github.com/REVrobotics/REV-Software-Binaries/releases/download/a301-27.0.0-prerelease.11/a301_27_0_0_prerelease_11.dfu)
 
 </details>
 


### PR DESCRIPTION
> [!WARNING]
> This update includes breaking changes. Please read the documentation carefully.

We understand that this may not be a great experience for some, but this change is a necessary evil and we have tried to make the transition as smooth as possible (as long as you read the documentation). 

This should the be the only time an update like this is needed.

- Adds A301 alpha 2 software resources
- Cleans up docs so that everything needed for A301 is not spread across two files

Issues closed:
- closes #310 
- closes #304 (improves wording and adds support for MRC override which requires an mrccomm update)
- closes #284 